### PR TITLE
add a force datastore reload method

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const functions = [
 module.exports = {
   getAll: (useWebKit = false) => CookieManager.getAll(useWebKit),
   clearAll: (useWebKit = false) => CookieManager.clearAll(useWebKit),
-  clearByName: (name, useWebKit = false) => CookieManager.clearByName(name, useWebKit),
+  clearByName: (name, useWebKit = false, webView) => CookieManager.clearByName(name, useWebKit, webView),
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
   set: (cookie, useWebKit = false) => CookieManager.set(cookie, useWebKit),
 };

--- a/index.js
+++ b/index.js
@@ -29,7 +29,6 @@ module.exports = {
   clearByName: (name, useWebKit = false) => CookieManager.clearByName(name, useWebKit),
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
   set: (cookie, useWebKit = false) => CookieManager.set(cookie, useWebKit),
-  forceDataStoreLoad:(wkWebView, useWebKit = false) => CookieManager.forceDataStoreLoad(wkWebView, useWebKit),
 };
 
 for (var i = 0; i < functions.length; i++) {

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ module.exports = {
   clearByName: (name, useWebKit = false) => CookieManager.clearByName(name, useWebKit),
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
   set: (cookie, useWebKit = false) => CookieManager.set(cookie, useWebKit),
+  forceDataStoreLoad:(wkWebView, useWebKit = false) => CookieManager.forceDataStoreLoad(wkWebView, useWebKit),
 };
 
 for (var i = 0; i < functions.length; i++) {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,10 @@ const functions = [
 module.exports = {
   getAll: (useWebKit = false) => CookieManager.getAll(useWebKit),
   clearAll: (useWebKit = false) => CookieManager.clearAll(useWebKit),
-  clearByName: (name, useWebKit = false, webView) => CookieManager.clearByName(name, useWebKit, webView),
+  clearByName: (name, useWebKit = false) => CookieManager.clearByName(name, useWebKit),
   get: (url, useWebKit = false) => CookieManager.get(url, useWebKit),
   set: (cookie, useWebKit = false) => CookieManager.set(cookie, useWebKit),
+  forceDataStoreLoad:(useWebKit = false, wkWebView) => CookieManager.forceDataStoreLoad(useWebKit, wkWebView),
 };
 
 for (var i = 0; i < functions.length; i++) {

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -204,8 +204,14 @@ RCT_EXPORT_METHOD(
 {
     if (useWebKit) {
         if (@available(iOS 11.0, *)) {
+            
             dispatch_async(dispatch_get_main_queue(), ^(){
+                
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
+                // WORKAROUND: Force the creation of the datastore by calling a method on it.
+                [cookieStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
+                                                              completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
+                
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     for(NSHTTPCookie *currentCookie in allCookies) {
                         if ([[currentCookie name] isEqualToString:name]) {
@@ -216,8 +222,12 @@ RCT_EXPORT_METHOD(
                             [cookieData setValue:currentCookie.domain forKey:NSHTTPCookieDomain];
                             [cookieData setValue:currentCookie.path forKey:NSHTTPCookiePath];
                             
+
+                            
                             NSHTTPCookie *newCookie = [NSHTTPCookie cookieWithProperties:cookieData];
                             [cookieStore deleteCookie:newCookie completionHandler:^{}];
+                            
+
                         }
                     }
                     resolve(nil);
@@ -234,26 +244,6 @@ RCT_EXPORT_METHOD(
             }
         }
         resolve(nil);
-    }
-}
-
-RCT_EXPORT_METHOD(
-  forceDataStoreLoad:(WKWebView *)webView
-  useWebKit:(BOOL)useWebKit,
-  cookie:(NSHTTPCookie)cookie,
-  resolver:(RCTPromiseResolveBlock)resolve
-  rejecter:(RCTPromiseRejectBlock)reject
-  )
-{
-    if (@available(iOS 11.0, *)) {
-        [webView.configuration.websiteDataStore.httpCookieStore setCookie:cookie
-                                                        completionHandler:^{
-                                                            [webView loadRequest:request];
-                                                        }];
-        
-        // WORKAROUND: Force the creation of the datastore by calling a method on it.
-        [webView.configuration.websiteDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
-                                                      completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
     }
 }
 

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -217,7 +217,7 @@ RCT_EXPORT_METHOD(
                             [cookieData setValue:currentCookie.path forKey:NSHTTPCookiePath];
                             
                             NSHTTPCookie *newCookie = [NSHTTPCookie cookieWithProperties:cookieData];
-                            [cookieStore deleteCookie:currentCookie completionHandler:^{}];
+                            [cookieStore deleteCookie:newCookie completionHandler:^{}];
                         }
                     }
                     resolve(nil);

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -208,7 +208,7 @@ RCT_EXPORT_METHOD(
             dispatch_async(dispatch_get_main_queue(), ^(){
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
                 
-                [defaultDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
+                [webView.configuration.websiteDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
                                        completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
                 
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -239,7 +239,8 @@ RCT_EXPORT_METHOD(
 
 RCT_EXPORT_METHOD(
   forceDataStoreLoad:(WKWebView *)webView
-  useWebKit:(BOOL)useWebKit
+  useWebKit:(BOOL)useWebKit,
+  cookie:(NSHTTPCookie)cookie,
   resolver:(RCTPromiseResolveBlock)resolve
   rejecter:(RCTPromiseRejectBlock)reject
   )

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -209,6 +209,14 @@ RCT_EXPORT_METHOD(
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     for(NSHTTPCookie *currentCookie in allCookies) {
                         if ([[currentCookie name] isEqualToString:name]) {
+                            
+                            NSMutableDictionary<NSHTTPCookiePropertyKey, id> *cookieData =  [NSMutableDictionary dictionary];
+                            [cookieData setValue:currentCookie.name forKey:NSHTTPCookieName];
+                            [cookieData setValue:currentCookie.value forKey:NSHTTPCookieValue];
+                            [cookieData setValue:currentCookie.domain forKey:NSHTTPCookieDomain];
+                            [cookieData setValue:currentCookie.path forKey:NSHTTPCookiePath];
+                            
+                            NSHTTPCookie *newCookie = [NSHTTPCookie cookieWithProperties:cookieData];
                             [cookieStore deleteCookie:currentCookie completionHandler:^{}];
                         }
                     }
@@ -226,6 +234,25 @@ RCT_EXPORT_METHOD(
             }
         }
         resolve(nil);
+    }
+}
+
+RCT_EXPORT_METHOD(
+  forceDataStoreLoad:(WKWebView *)webView
+  useWebKit:(BOOL)useWebKit
+  resolver:(RCTPromiseResolveBlock)resolve
+  rejecter:(RCTPromiseRejectBlock)reject)
+  )
+{
+    if (@available(iOS 11.0, *)) {
+        [webView.configuration.websiteDataStore.httpCookieStore setCookie:cookie
+                                                        completionHandler:^{
+                                                            [webView loadRequest:request];
+                                                        }];
+        
+        // WORKAROUND: Force the creation of the datastore by calling a method on it.
+        [webView.configuration.websiteDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
+                                                      completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
     }
 }
 

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -206,11 +206,10 @@ RCT_EXPORT_METHOD(
         if (@available(iOS 11.0, *)) {
             
             dispatch_async(dispatch_get_main_queue(), ^(){
-                
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
-                // WORKAROUND: Force the creation of the datastore by calling a method on it.
-                [cookieStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
-                                                              completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
+                
+                [defaultDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
+                                       completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
                 
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     for(NSHTTPCookie *currentCookie in allCookies) {

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -208,9 +208,6 @@ RCT_EXPORT_METHOD(
             dispatch_async(dispatch_get_main_queue(), ^(){
                 WKHTTPCookieStore *cookieStore = [[WKWebsiteDataStore defaultDataStore] httpCookieStore];
                 
-                [webView.configuration.websiteDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
-                                       completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
-                
                 [cookieStore getAllCookies:^(NSArray<NSHTTPCookie *> *allCookies) {
                     for(NSHTTPCookie *currentCookie in allCookies) {
                         if ([[currentCookie name] isEqualToString:name]) {
@@ -242,6 +239,23 @@ RCT_EXPORT_METHOD(
                 [cookieStorage deleteCookie:c];
             }
         }
+        resolve(nil);
+    }
+}
+
+RCT_EXPORT_METHOD(
+      forceDataStoreReload:(BOOL)useWebKit
+      webView:(WKWebView *)webView
+      resolver:(RCTPromiseResolveBlock)resolve
+      rejecter:(RCTPromiseRejectBlock)reject)
+{
+    if (@available(iOS 11.0, *)) {
+        dispatch_async(dispatch_get_main_queue(), ^(){
+            [webView.configuration.websiteDataStore fetchDataRecordsOfTypes:[NSSet<NSString *> setWithObject:WKWebsiteDataTypeCookies]
+                                                          completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {}];
+            resolve(nil);
+        });
+    } else {
         resolve(nil);
     }
 }

--- a/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
+++ b/ios/RNCookieManagerIOS/RNCookieManagerIOS.m
@@ -241,7 +241,7 @@ RCT_EXPORT_METHOD(
   forceDataStoreLoad:(WKWebView *)webView
   useWebKit:(BOOL)useWebKit
   resolver:(RCTPromiseResolveBlock)resolve
-  rejecter:(RCTPromiseRejectBlock)reject)
+  rejecter:(RCTPromiseRejectBlock)reject
   )
 {
     if (@available(iOS 11.0, *)) {

--- a/ios/Tests/Info.plist
+++ b/ios/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/ios/Tests/Tests.m
+++ b/ios/Tests/Tests.m
@@ -1,0 +1,36 @@
+//
+//  Tests.m
+//  Tests
+//
+//  Created by Falkner, Liz on 2/25/19.
+//
+
+#import <XCTest/XCTest.h>
+
+@interface Tests : XCTestCase
+
+@end
+
+@implementation Tests
+
+- (void)setUp {
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+}
+
+- (void)testExample {
+    // This is an example of a functional test case.
+    // Use XCTAssert and related functions to verify your tests produce the correct results.
+}
+
+- (void)testPerformanceExample {
+    // This is an example of a performance test case.
+    [self measureBlock:^{
+        // Put the code you want to measure the time of here.
+    }];
+}
+
+@end


### PR DESCRIPTION
Used the same 'rename' logic as the previously existing 'clear all' method. Added a method to force datastore reload per the bug listed here:
https://bugs.webkit.org/show_bug.cgi?id=185483